### PR TITLE
Function block doesn't cast Lists to Singles anymore if there is only…

### DIFF
--- a/RuriLib/Blocks/BlockFunction.cs
+++ b/RuriLib/Blocks/BlockFunction.cs
@@ -660,7 +660,8 @@ namespace RuriLib
                 outputs.Add(outputString);
             }
 
-            InsertVariables(data, isCapture, outputs.Count > 1, outputs, variableName, "", "");
+            var isList = outputs.Count > 1 || InputString.Contains("[*]") || InputString.Contains("(*)") || InputString.Contains("{*}");
+            InsertVariables(data, isCapture, isList, outputs, variableName, "", "");
         }
 
         #region Base64


### PR DESCRIPTION
… one element inside them.